### PR TITLE
deps: update to go 1.26

### DIFF
--- a/.github/workflows/check-go-licenses.yaml
+++ b/.github/workflows/check-go-licenses.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
 
 permissions:
   contents: read

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Run build and e2e test
         run: make e2e.run

--- a/.github/workflows/reviewable_check_diff.yaml
+++ b/.github/workflows/reviewable_check_diff.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
-        go-version: '1.25'
+        go-version: '1.26'
 
     - name: Install go imports
       run: |

--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 as builder
+FROM golang:1.26 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/SAP/crossplane-provider-hana
 
-go 1.25.0
-
-toolchain go1.25.7
+go 1.26
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/internal/clients/hana/hana.go
+++ b/internal/clients/hana/hana.go
@@ -87,11 +87,9 @@ func (h *hanaDB) Disconnect() error {
 	h.dbs.Range(func(_, val any) bool {
 		db, ok := val.(*sql.DB)
 		if ok {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				_ = db.Close()
-			}()
+			})
 		} else {
 			// Log warning when loaded value is not *sql.DB
 			h.logger.Info("Warning: sync.Map loaded value that is not *sql.DB", "type", fmt.Sprintf("%T", val))


### PR DESCRIPTION
This PR updates the Go version to 1.26.