### PR TITLE
Optimize Audit Policy Actions

### DIFF
--- a/internal/clients/hana/auditpolicy/auditpolicy_client.go
+++ b/internal/clients/hana/auditpolicy/auditpolicy_client.go
@@ -323,7 +323,9 @@ func groupActions(actions []parsedAction) []parsedAction {
 	noUserMap, forPrincipalsMap, forPrincipalsSelfMap, exceptForPrincipalsMap, exceptForPrincipalsSelfMap := splitActions(actions)
 
 	groupedActions := make([]parsedAction, 0, 1+len(forPrincipalsMap)+len(exceptForPrincipalsMap))
-	groupedActions = append(groupedActions, parsedAction{actionNames: noUserMap})
+	if len(noUserMap) > 0 {
+		groupedActions = append(groupedActions, parsedAction{actionNames: noUserMap})
+	}
 
 	for principalsString, actionNames := range forPrincipalsMap {
 		principals := forPrincipalsSelfMap[principalsString]

--- a/internal/clients/hana/auditpolicy/auditpolicy_client.go
+++ b/internal/clients/hana/auditpolicy/auditpolicy_client.go
@@ -3,7 +3,9 @@ package auditpolicy
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/SAP/crossplane-provider-hana/apis/admin/v1alpha1"
@@ -47,17 +49,21 @@ func (c Client) Read(ctx context.Context, parameters *v1alpha1.AuditPolicyParame
 		var policyName string
 		var eventStatus string
 		var eventAction sql.NullString
+		var principalName sql.NullString
+		var exceptPrincipalName sql.NullString
+		var principalType sql.NullString
 		var eventLevel string
 		var retentionPeriod sql.NullInt64
 		var isActive string
-		err = policyActionRows.Scan(&policyName, &eventStatus, &eventAction, &eventLevel, &retentionPeriod, &isActive)
+		err = policyActionRows.Scan(&policyName, &eventStatus, &eventAction, &principalName, &exceptPrincipalName, &principalType, &eventLevel, &retentionPeriod, &isActive)
 		if err != nil {
 			return nil, err
 		}
 		observed.PolicyName = policyName
 		observed.AuditStatus = strings.TrimSuffix(eventStatus, " EVENTS")
 		if eventAction.Valid {
-			observed.AuditActions = append(observed.AuditActions, eventAction.String)
+			actionString := readActionString(eventAction, principalName, exceptPrincipalName, principalType)
+			observed.AuditActions = append(observed.AuditActions, actionString)
 		}
 		observed.AuditLevel = eventLevel
 		if retentionPeriod.Valid {
@@ -81,19 +87,17 @@ func (c Client) Read(ctx context.Context, parameters *v1alpha1.AuditPolicyParame
 // Create a new audit policy
 func (c Client) Create(ctx context.Context, parameters *v1alpha1.AuditPolicyParameters) error {
 
-	query := prepareCreateSql(parameters)
-
-	_, err := c.ExecContext(ctx, query)
-
-	if err != nil {
-		return err
-	}
-
-	if parameters.Enabled != nil && *parameters.Enabled {
-		enableQuery := prepareEnableDisablePolicySql(parameters)
-		_, err = c.ExecContext(ctx, enableQuery)
+	for _, query := range prepareCreateSql(parameters) {
+		_, err := c.ExecContext(ctx, query)
 		if err != nil {
 			return err
+		}
+		if parameters.Enabled != nil && *parameters.Enabled {
+			enableQuery := prepareEnableDisablePolicySql(parameters)
+			_, err = c.ExecContext(ctx, enableQuery)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -150,22 +154,241 @@ func (c Client) Delete(ctx context.Context, parameters *v1alpha1.AuditPolicyPara
 	return nil
 }
 
-func prepareCreateSql(parameters *v1alpha1.AuditPolicyParameters) string {
-	query := fmt.Sprintf("CREATE AUDIT POLICY %s AUDITING %s", parameters.PolicyName, parameters.AuditStatus)
+func OptimizeAuditActions(actionStrings []string) ([]string, error) {
+	for i := range actionStrings {
+		actionStrings[i] = strings.ReplaceAll(actionStrings[i], " FOR PRINCIPALS ALL USERS", "")
+	}
+	groupedActions := []string{}
+	parsedActions := []parsedAction{}
+	for _, actionString := range actionStrings {
+		actions, err := parseIntoActions(actionString)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing action string '%s': %w", actionString, err)
+		}
+		parsedActions = append(parsedActions, actions...)
+	}
+	grouped := groupActions(parsedActions)
+	if len(grouped) > 1 {
+		return nil, errors.New("only one audit action is supported at the moment")
+	}
+	for _, ga := range grouped {
+		groupedActions = append(groupedActions, stringifyParsedAction(ga))
+	}
+	return groupedActions, nil
+}
 
-	if len(parameters.AuditActions) > 0 {
-		for _, action := range parameters.AuditActions {
-			query += fmt.Sprintf(" %s,", action)
+type parsedPrincipal struct {
+	user      string
+	usergroup string
+}
+
+type parsedAction struct {
+	actionNames    []string
+	auditFor       []parsedPrincipal
+	auditExceptFor []parsedPrincipal
+}
+
+func readActionString(eventAction sql.NullString, principalName sql.NullString, exceptPrincipalName sql.NullString, principalType sql.NullString) string {
+	actionString := eventAction.String
+	var nameOfPrincipal string
+	if principalName.Valid {
+		actionString += " FOR PRINCIPALS"
+		nameOfPrincipal = principalName.String
+	} else if exceptPrincipalName.Valid {
+		actionString += " EXCEPT FOR PRINCIPALS"
+		nameOfPrincipal = exceptPrincipalName.String
+	}
+	if principalType.Valid {
+		actionString += " " + principalType.String
+	}
+	if nameOfPrincipal != "" {
+		actionString += " " + nameOfPrincipal
+	}
+	return actionString
+}
+
+func parseUserEntry(userEntry string) (parsedPrincipal, error) {
+	userEntry = strings.TrimSpace(userEntry)
+	if strings.HasPrefix(userEntry, "USERGROUP ") {
+		usergroup := strings.TrimPrefix(userEntry, "USERGROUP ")
+		return parsedPrincipal{usergroup: usergroup}, nil
+	} else if strings.HasPrefix(userEntry, "USER ") {
+		user := strings.TrimPrefix(userEntry, "USER ")
+		return parsedPrincipal{user: user}, nil
+	}
+	return parsedPrincipal{}, fmt.Errorf("invalid principal entry: %s", userEntry)
+}
+
+func parseUsersList(usersPart string) ([]parsedPrincipal, error) {
+	usersPart = strings.TrimSpace(usersPart)
+	parsedUsers := []parsedPrincipal{}
+
+	if strings.HasPrefix(usersPart, "PRINCIPALS ") {
+		usersList := strings.TrimPrefix(usersPart, "PRINCIPALS ")
+		for _, userEntry := range strings.Split(usersList, ",") {
+			parsedUser, err := parseUserEntry(userEntry)
+			if err != nil {
+				return nil, err
+			}
+			parsedUsers = append(parsedUsers, parsedUser)
+		}
+	} else {
+		for _, userEntry := range strings.Split(usersPart, ",") {
+			parsedUsers = append(parsedUsers, parsedPrincipal{user: userEntry})
 		}
 	}
-	query = strings.TrimSuffix(query, ",")
-	query += fmt.Sprintf(" LEVEL %s TRAIL TYPE TABLE RETENTION %d", parameters.AuditLevel, *parameters.AuditTrailRetention)
+	return parsedUsers, nil
+}
 
-	return query
+func parseIntoActions(action string) ([]parsedAction, error) {
+	actions := []parsedAction{}
+	actionNames := action
+
+	partialAction := parsedAction{}
+	if exceptForParts := strings.SplitN(action, " EXCEPT FOR ", 2); len(exceptForParts) == 2 {
+		actionNames = exceptForParts[0]
+		afterExceptFor := exceptForParts[1]
+		partialUsers, err := parseUsersList(afterExceptFor)
+		if err != nil {
+			return nil, err
+		}
+		partialAction.auditExceptFor = partialUsers
+	} else if forParts := strings.SplitN(exceptForParts[0], " FOR ", 2); len(forParts) == 2 {
+		actionNames = forParts[0]
+		afterFor := forParts[1]
+		partialUsers, err := parseUsersList(afterFor)
+		if err != nil {
+			return nil, err
+		}
+		partialAction.auditFor = partialUsers
+	}
+	for _, actionName := range strings.Split(actionNames, ",") {
+		action := parsedAction{
+			actionNames:    []string{strings.ToUpper(strings.TrimSpace(actionName))},
+			auditFor:       partialAction.auditFor,
+			auditExceptFor: partialAction.auditExceptFor,
+		}
+		actions = append(actions, action)
+	}
+	return actions, nil
+}
+
+func getUniqueString(input []string) string {
+	sorted := make([]string, len(input))
+	copy(sorted, input)
+	sort.Strings(sorted)
+	sorted = utils.ArrayToUpper(sorted)
+	uniqueString := strings.Join(sorted, ",")
+	return uniqueString
+}
+
+func updatePrincipals(actionNames []string, principals []parsedPrincipal, principalMap map[string][]string, principalSelfMap map[string][]parsedPrincipal) {
+	users := []string{}
+	usergroups := []string{}
+	for _, principal := range principals {
+		if principal.user != "" {
+			users = append(users, principal.user)
+		} else if principal.usergroup != "" {
+			usergroups = append(usergroups, principal.usergroup)
+		}
+	}
+	uniqueUsersString := getUniqueString(users)
+	uniqueUsergroupsString := getUniqueString(usergroups)
+	uniqueString := uniqueUsersString + ";" + uniqueUsergroupsString
+	principalMap[uniqueString] = append(principalMap[uniqueString], actionNames...)
+	principalSelfMap[uniqueString] = principals
+}
+
+func splitActions(actions []parsedAction) (noUserMap []string, forPrincipalsMap map[string][]string, forPrincipalsSelfMap map[string][]parsedPrincipal, exceptForPrincipalsMap map[string][]string, exceptForPrincipalsSelfMap map[string][]parsedPrincipal) {
+	noUserMap = []string{}
+	forPrincipalsMap = make(map[string][]string)
+	forPrincipalsSelfMap = make(map[string][]parsedPrincipal)
+	exceptForPrincipalsMap = make(map[string][]string)
+	exceptForPrincipalsSelfMap = make(map[string][]parsedPrincipal)
+
+	for _, action := range actions {
+		switch {
+		case len(action.auditFor) > 0:
+			updatePrincipals(action.actionNames, action.auditFor, forPrincipalsMap, forPrincipalsSelfMap)
+		case len(action.auditExceptFor) > 0:
+			updatePrincipals(action.actionNames, action.auditExceptFor, exceptForPrincipalsMap, exceptForPrincipalsSelfMap)
+		default:
+			noUserMap = append(noUserMap, action.actionNames...)
+		}
+	}
+	return noUserMap, forPrincipalsMap, forPrincipalsSelfMap, exceptForPrincipalsMap, exceptForPrincipalsSelfMap
+}
+
+func groupActions(actions []parsedAction) []parsedAction {
+	noUserMap, forPrincipalsMap, forPrincipalsSelfMap, exceptForPrincipalsMap, exceptForPrincipalsSelfMap := splitActions(actions)
+
+	groupedActions := make([]parsedAction, 0, 1+len(forPrincipalsMap)+len(exceptForPrincipalsMap))
+	groupedActions = append(groupedActions, parsedAction{actionNames: noUserMap})
+
+	for principalsString, actionNames := range forPrincipalsMap {
+		principals := forPrincipalsSelfMap[principalsString]
+		groupedActions = append(groupedActions, parsedAction{
+			actionNames: actionNames,
+			auditFor:    principals,
+		})
+	}
+	for principalsString, actionNames := range exceptForPrincipalsMap {
+		principals := exceptForPrincipalsSelfMap[principalsString]
+		groupedActions = append(groupedActions, parsedAction{
+			actionNames:    actionNames,
+			auditExceptFor: principals,
+		})
+	}
+	return groupedActions
+}
+
+func stringifyUserList(principals []parsedPrincipal) string {
+	if len(principals) == 0 {
+		return ""
+	}
+
+	principalStrs := []string{}
+	for _, principal := range principals {
+		if principal.user != "" {
+			principalStrs = append(principalStrs, fmt.Sprintf("USER %s", principal.user))
+		} else if principal.usergroup != "" {
+			principalStrs = append(principalStrs, fmt.Sprintf("USERGROUP %s", principal.usergroup))
+		}
+	}
+	return "PRINCIPALS " + strings.Join(principalStrs, ", ")
+}
+
+func stringifyParsedAction(pa parsedAction) string {
+	actionStr := strings.Join(pa.actionNames, ", ")
+	if pa.auditFor != nil {
+		if principals := stringifyUserList(pa.auditFor); principals != "" {
+			actionStr += fmt.Sprintf(" FOR %s", principals)
+		}
+	} else if pa.auditExceptFor != nil {
+		if principals := stringifyUserList(pa.auditExceptFor); principals != "" {
+			actionStr += fmt.Sprintf(" EXCEPT FOR %s", principals)
+		}
+	}
+	return actionStr
+}
+
+func prepareCreateSql(parameters *v1alpha1.AuditPolicyParameters) []string {
+	queryLeft := fmt.Sprintf(`CREATE AUDIT POLICY "%s" AUDITING %s`, utils.EscapeDoubleQuotes(parameters.PolicyName), parameters.AuditStatus)
+	queryRight := fmt.Sprintf("LEVEL %s TRAIL TYPE TABLE RETENTION %d", parameters.AuditLevel, *parameters.AuditTrailRetention)
+
+	queries := []string{}
+	if len(parameters.AuditActions) == 0 {
+		return []string{fmt.Sprintf("%s %s", queryLeft, queryRight)}
+	}
+
+	for _, action := range parameters.AuditActions {
+		queries = append(queries, fmt.Sprintf("%s %s %s", queryLeft, action, queryRight))
+	}
+	return queries
 }
 
 func getSelectSql() string {
-	return "SELECT AUDIT_POLICY_NAME, EVENT_STATUS, EVENT_ACTION, EVENT_LEVEL, RETENTION_PERIOD, IS_AUDIT_POLICY_ACTIVE FROM AUDIT_POLICIES WHERE AUDIT_POLICY_NAME = ?"
+	return "SELECT AUDIT_POLICY_NAME, EVENT_STATUS, EVENT_ACTION, PRINCIPAL_NAME, EXCEPT_PRINCIPAL_NAME, PRINCIPAL_TYPE, EVENT_LEVEL, RETENTION_PERIOD, IS_AUDIT_POLICY_ACTIVE FROM AUDIT_POLICIES WHERE AUDIT_POLICY_NAME = ?"
 }
 
 func prepareEnableDisablePolicySql(parameters *v1alpha1.AuditPolicyParameters) string {

--- a/internal/clients/hana/auditpolicy/auditpolicy_client_test.go
+++ b/internal/clients/hana/auditpolicy/auditpolicy_client_test.go
@@ -3,6 +3,8 @@ package auditpolicy
 import (
 	"context"
 	"database/sql"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -13,6 +15,359 @@ import (
 	"github.com/SAP/crossplane-provider-hana/apis/admin/v1alpha1"
 	"github.com/SAP/crossplane-provider-hana/internal/clients/fake"
 )
+
+func sortedStrings(ss []string) []string {
+	out := make([]string, len(ss))
+	copy(out, ss)
+	sort.Strings(out)
+	return out
+}
+
+func splitAndSort(s string) []string {
+	parts := strings.Split(s, ", ")
+	sort.Strings(parts)
+	return parts
+}
+
+func TestOptimizeAuditActions(t *testing.T) {
+	type args struct {
+		actionStrings []string
+	}
+	type want struct {
+		result []string
+		errMsg string
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"EmptyInput": {
+			reason: "Empty input produces empty output without error",
+			args:   args{actionStrings: []string{}},
+			want:   want{result: []string{}},
+		},
+		"SingleAction": {
+			reason: "A single action with no principal is returned as-is",
+			args:   args{actionStrings: []string{"GRANT"}},
+			want:   want{result: []string{"GRANT"}},
+		},
+		"MultipleActionsGroupedIntoOne": {
+			reason: "Multiple no-principal actions across separate strings are merged into a single comma-separated action",
+			args:   args{actionStrings: []string{"GRANT", "REVOKE", "SELECT"}},
+			want:   want{result: []string{"GRANT, REVOKE, SELECT"}},
+		},
+		"CommaSeparatedActionsInOneString": {
+			reason: "A single string with comma-separated actions is normalized the same as separate strings",
+			args:   args{actionStrings: []string{"GRANT,REVOKE"}},
+			want:   want{result: []string{"GRANT, REVOKE"}},
+		},
+		"AllUsersStripped": {
+			reason: "FOR PRINCIPALS ALL USERS suffix is removed before processing",
+			args:   args{actionStrings: []string{"GRANT FOR PRINCIPALS ALL USERS"}},
+			want:   want{result: []string{"GRANT"}},
+		},
+		"MultipleAllUsersStrippedAndGrouped": {
+			reason: "Multiple actions with FOR PRINCIPALS ALL USERS are stripped and merged",
+			args:   args{actionStrings: []string{"GRANT FOR PRINCIPALS ALL USERS", "REVOKE FOR PRINCIPALS ALL USERS"}},
+			want:   want{result: []string{"GRANT, REVOKE"}},
+		},
+		"LowercaseActionsNormalized": {
+			reason: "Action names are uppercased during grouping",
+			args:   args{actionStrings: []string{"grant", "revoke"}},
+			want:   want{result: []string{"GRANT, REVOKE"}},
+		},
+		"DuplicateActionsGrouped": {
+			reason: "Duplicate action names across separate strings are both included in the merged result",
+			args:   args{actionStrings: []string{"GRANT", "GRANT"}},
+			want:   want{result: []string{"GRANT, GRANT"}},
+		},
+		"NamedUserPrincipalSucceeds": {
+			reason: "A single FOR PRINCIPALS USER action produces one group and is returned without error",
+			args:   args{actionStrings: []string{"GRANT FOR PRINCIPALS USER ALICE"}},
+			want:   want{result: []string{"GRANT FOR PRINCIPALS USER ALICE"}},
+		},
+		"MixedNoUserAndForPrincipalFails": {
+			reason: "Mixing unscoped actions with FOR PRINCIPALS actions creates multiple groups and must error",
+			args:   args{actionStrings: []string{"GRANT", "REVOKE FOR PRINCIPALS USER ALICE"}},
+			want:   want{errMsg: "only one audit action is supported at the moment"},
+		},
+		"TwoDistinctForPrincipalGroupsFail": {
+			reason: "Actions scoped to two different users form two separate groups and must error",
+			args:   args{actionStrings: []string{"GRANT FOR PRINCIPALS USER ALICE", "REVOKE FOR PRINCIPALS USER BOB"}},
+			want:   want{errMsg: "only one audit action is supported at the moment"},
+		},
+		"InvalidPrincipalEntryFails": {
+			reason: "A malformed principal entry without USER or USERGROUP prefix returns a parse error",
+			args:   args{actionStrings: []string{"GRANT FOR PRINCIPALS BADINPUT"}},
+			want:   want{errMsg: "error parsing action string"},
+		},
+		"ExceptForPrincipalSucceeds": {
+			reason: "A single EXCEPT FOR PRINCIPALS action produces one group and is returned without error",
+			args:   args{actionStrings: []string{"GRANT EXCEPT FOR PRINCIPALS USER ALICE"}},
+			want:   want{result: []string{"GRANT EXCEPT FOR PRINCIPALS USER ALICE"}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := OptimizeAuditActions(tc.args.actionStrings)
+
+			if tc.want.errMsg != "" {
+				if err == nil {
+					t.Errorf("\n%s\nOptimizeAuditActions(...): expected error containing %q, got nil", tc.reason, tc.want.errMsg)
+					return
+				}
+				if !strings.Contains(err.Error(), tc.want.errMsg) {
+					t.Errorf("\n%s\nOptimizeAuditActions(...): expected error containing %q, got %q", tc.reason, tc.want.errMsg, err.Error())
+				}
+				return
+			}
+
+			normalizedWant := make([][]string, len(tc.want.result))
+			for i, s := range tc.want.result {
+				normalizedWant[i] = splitAndSort(s)
+			}
+			normalizedGot := make([][]string, len(got))
+			for i, s := range got {
+				normalizedGot[i] = splitAndSort(s)
+			}
+			if diff := cmp.Diff(normalizedWant, normalizedGot); diff != "" {
+				t.Errorf("\n%s\nOptimizeAuditActions(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestGroupActions(t *testing.T) {
+	cases := map[string]struct {
+		reason  string
+		actions []parsedAction
+		want    []parsedAction
+	}{
+		"EmptyInput": {
+			reason:  "Empty input produces no groups",
+			actions: []parsedAction{},
+			want:    []parsedAction{},
+		},
+		"SingleNoUser": {
+			reason:  "A single action without principals is placed in the no-user group",
+			actions: []parsedAction{{actionNames: []string{"GRANT"}}},
+			want:    []parsedAction{{actionNames: []string{"GRANT"}}},
+		},
+		"MultipleNoUserMerged": {
+			reason: "Multiple no-principal actions are merged into one group",
+			actions: []parsedAction{
+				{actionNames: []string{"GRANT"}},
+				{actionNames: []string{"REVOKE"}},
+			},
+			want: []parsedAction{{actionNames: []string{"GRANT", "REVOKE"}}},
+		},
+		"ForPrincipalsSameUserGrouped": {
+			reason: "Actions sharing the same FOR principal are merged into one group",
+			actions: []parsedAction{
+				{actionNames: []string{"GRANT"}, auditFor: []parsedPrincipal{{user: "ALICE"}}},
+				{actionNames: []string{"REVOKE"}, auditFor: []parsedPrincipal{{user: "ALICE"}}},
+			},
+			want: []parsedAction{
+				{actionNames: []string{"GRANT", "REVOKE"}, auditFor: []parsedPrincipal{{user: "ALICE"}}},
+			},
+		},
+		"ForPrincipalsDifferentUsersSeparated": {
+			reason: "Actions with different FOR principals remain in separate groups",
+			actions: []parsedAction{
+				{actionNames: []string{"GRANT"}, auditFor: []parsedPrincipal{{user: "ALICE"}}},
+				{actionNames: []string{"REVOKE"}, auditFor: []parsedPrincipal{{user: "BOB"}}},
+			},
+			want: []parsedAction{
+				{actionNames: []string{"GRANT"}, auditFor: []parsedPrincipal{{user: "ALICE"}}},
+				{actionNames: []string{"REVOKE"}, auditFor: []parsedPrincipal{{user: "BOB"}}},
+			},
+		},
+		"ExceptForPrincipalGrouped": {
+			reason: "Actions sharing the same EXCEPT FOR principal are merged into one group",
+			actions: []parsedAction{
+				{actionNames: []string{"GRANT"}, auditExceptFor: []parsedPrincipal{{user: "ALICE"}}},
+				{actionNames: []string{"REVOKE"}, auditExceptFor: []parsedPrincipal{{user: "ALICE"}}},
+			},
+			want: []parsedAction{
+				{actionNames: []string{"GRANT", "REVOKE"}, auditExceptFor: []parsedPrincipal{{user: "ALICE"}}},
+			},
+		},
+		"MixedNoUserAndForPrincipalSeparated": {
+			reason: "No-principal actions and FOR principal actions produce separate groups",
+			actions: []parsedAction{
+				{actionNames: []string{"GRANT"}},
+				{actionNames: []string{"REVOKE"}, auditFor: []parsedPrincipal{{user: "ALICE"}}},
+			},
+			want: []parsedAction{
+				{actionNames: []string{"GRANT"}},
+				{actionNames: []string{"REVOKE"}, auditFor: []parsedPrincipal{{user: "ALICE"}}},
+			},
+		},
+		"UsergroupPrincipalGrouped": {
+			reason: "Actions sharing the same USERGROUP principal are merged into one group",
+			actions: []parsedAction{
+				{actionNames: []string{"GRANT"}, auditFor: []parsedPrincipal{{usergroup: "ADMINS"}}},
+				{actionNames: []string{"REVOKE"}, auditFor: []parsedPrincipal{{usergroup: "ADMINS"}}},
+			},
+			want: []parsedAction{
+				{actionNames: []string{"GRANT", "REVOKE"}, auditFor: []parsedPrincipal{{usergroup: "ADMINS"}}},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := groupActions(tc.actions)
+			if len(got) != len(tc.want) {
+				t.Errorf("\n%s\ngroupActions(...): want %d groups, got %d", tc.reason, len(tc.want), len(got))
+				return
+			}
+			for i, wantGroup := range tc.want {
+				gotGroup := got[i]
+				if diff := cmp.Diff(sortedStrings(wantGroup.actionNames), sortedStrings(gotGroup.actionNames)); diff != "" {
+					t.Errorf("\n%s\ngroupActions(...) group[%d] actionNames: -want, +got:\n%s\n", tc.reason, i, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestParseIntoActions(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		input  string
+		want   []parsedAction
+		errMsg string
+	}{
+		"SingleAction": {
+			reason: "A bare action name yields one parsedAction with no principals",
+			input:  "GRANT",
+			want:   []parsedAction{{actionNames: []string{"GRANT"}}},
+		},
+		"CommaSeparatedActions": {
+			reason: "Comma-separated actions are split into separate parsedActions",
+			input:  "GRANT,REVOKE",
+			want: []parsedAction{
+				{actionNames: []string{"GRANT"}},
+				{actionNames: []string{"REVOKE"}},
+			},
+		},
+		"ForPrincipalsUser": {
+			reason: "FOR PRINCIPALS USER X is parsed into auditFor with user set",
+			input:  "GRANT FOR PRINCIPALS USER ALICE",
+			want: []parsedAction{
+				{actionNames: []string{"GRANT"}, auditFor: []parsedPrincipal{{user: "ALICE"}}},
+			},
+		},
+		"ExceptForPrincipalsUser": {
+			reason: "EXCEPT FOR PRINCIPALS USER X is parsed into auditExceptFor with user set",
+			input:  "GRANT EXCEPT FOR PRINCIPALS USER ALICE",
+			want: []parsedAction{
+				{actionNames: []string{"GRANT"}, auditExceptFor: []parsedPrincipal{{user: "ALICE"}}},
+			},
+		},
+		"ForPrincipalsUsergroup": {
+			reason: "FOR PRINCIPALS USERGROUP G is parsed into auditFor with usergroup set",
+			input:  "GRANT FOR PRINCIPALS USERGROUP ADMINS",
+			want: []parsedAction{
+				{actionNames: []string{"GRANT"}, auditFor: []parsedPrincipal{{usergroup: "ADMINS"}}},
+			},
+		},
+		"InvalidPrincipalEntry": {
+			reason: "A principal entry without USER or USERGROUP prefix produces an error",
+			input:  "GRANT FOR PRINCIPALS BADINPUT",
+			errMsg: "invalid principal entry",
+		},
+		"LowercaseActionNormalized": {
+			reason: "Lowercase action names are uppercased",
+			input:  "grant",
+			want:   []parsedAction{{actionNames: []string{"GRANT"}}},
+		},
+		"ActionWithWhitespace": {
+			reason: "Leading and trailing whitespace around action names is trimmed",
+			input:  " GRANT , REVOKE ",
+			want: []parsedAction{
+				{actionNames: []string{"GRANT"}},
+				{actionNames: []string{"REVOKE"}},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := parseIntoActions(tc.input)
+
+			if tc.errMsg != "" {
+				if err == nil {
+					t.Errorf("\n%s\nparseIntoActions(%q): expected error containing %q, got nil", tc.reason, tc.input, tc.errMsg)
+					return
+				}
+				if !strings.Contains(err.Error(), tc.errMsg) {
+					t.Errorf("\n%s\nparseIntoActions(%q): expected error containing %q, got %q", tc.reason, tc.input, tc.errMsg, err.Error())
+				}
+				return
+			}
+
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(parsedAction{}, parsedPrincipal{})); diff != "" {
+				t.Errorf("\n%s\nparseIntoActions(%q): -want, +got:\n%s\n", tc.reason, tc.input, diff)
+			}
+		})
+	}
+}
+
+func TestStringifyParsedAction(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		input  parsedAction
+		want   string
+	}{
+		"NoUser": {
+			reason: "Action with no principals is serialized as a bare comma-separated list",
+			input:  parsedAction{actionNames: []string{"GRANT", "REVOKE"}},
+			want:   "GRANT, REVOKE",
+		},
+		"ForUser": {
+			reason: "Action with auditFor user is serialized with FOR PRINCIPALS USER",
+			input:  parsedAction{actionNames: []string{"GRANT"}, auditFor: []parsedPrincipal{{user: "ALICE"}}},
+			want:   "GRANT FOR PRINCIPALS USER ALICE",
+		},
+		"ForUsergroup": {
+			reason: "Action with auditFor usergroup is serialized with FOR PRINCIPALS USERGROUP",
+			input:  parsedAction{actionNames: []string{"GRANT"}, auditFor: []parsedPrincipal{{usergroup: "ADMINS"}}},
+			want:   "GRANT FOR PRINCIPALS USERGROUP ADMINS",
+		},
+		"ExceptForUser": {
+			reason: "Action with auditExceptFor user is serialized with EXCEPT FOR PRINCIPALS USER",
+			input:  parsedAction{actionNames: []string{"GRANT"}, auditExceptFor: []parsedPrincipal{{user: "ALICE"}}},
+			want:   "GRANT EXCEPT FOR PRINCIPALS USER ALICE",
+		},
+		"MultipleForUsers": {
+			reason: "Multiple auditFor users are joined with comma-space",
+			input: parsedAction{
+				actionNames: []string{"GRANT"},
+				auditFor:    []parsedPrincipal{{user: "ALICE"}, {user: "BOB"}},
+			},
+			want: "GRANT FOR PRINCIPALS USER ALICE, USER BOB",
+		},
+		"EmptyActionNames": {
+			reason: "Empty action name list produces an empty string",
+			input:  parsedAction{actionNames: []string{}},
+			want:   "",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := stringifyParsedAction(tc.input)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nstringifyParsedAction(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}
 
 func TestRead(t *testing.T) {
 	errBoom := errors.New("boom")

--- a/internal/clients/hana/privilege/privilege.go
+++ b/internal/clients/hana/privilege/privilege.go
@@ -402,7 +402,7 @@ func parseRoleString(roleStr string) (Role, error) {
 		}, nil
 	}
 	// Check for invalid grant option usage
-	upperStr := strings.ToUpper(strings.TrimSpace(roleStr))
+	upperStr := strings.TrimSpace(roleStr)
 	if strings.HasSuffix(upperStr, "WITH GRANT OPTION") {
 		return Role{}, fmt.Errorf(errRoleInvalidGrantOption, roleStr)
 	}

--- a/internal/controller/auditpolicy/reconciler.go
+++ b/internal/controller/auditpolicy/reconciler.go
@@ -350,7 +350,7 @@ func buildDesiredParameters(cr *v1alpha1.AuditPolicy) (*v1alpha1.AuditPolicyPara
 		return nil, err
 	}
 	return &v1alpha1.AuditPolicyParameters{
-		PolicyName:          strings.ToUpper(cr.Spec.ForProvider.PolicyName),
+		PolicyName:          cr.Spec.ForProvider.PolicyName,
 		AuditStatus:         strings.ToUpper(cr.Spec.ForProvider.AuditStatus),
 		AuditActions:        auditActions,
 		AuditLevel:          strings.ToUpper(cr.Spec.ForProvider.AuditLevel),

--- a/internal/controller/auditpolicy/reconciler.go
+++ b/internal/controller/auditpolicy/reconciler.go
@@ -157,9 +157,21 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	c.log.Info("Observing auditpolicy resource", "name", cr.Name)
 
-	parameters := buildDesiredParameters(cr)
+	parameters, err := buildDesiredParameters(cr)
+	if err != nil {
+		return managed.ExternalObservation{}, errors.Wrap(err, "error building desired parameters for observation")
+	}
 
 	observed, err := c.client.Read(ctx, parameters)
+	if err != nil {
+		c.log.Info("Error observing auditpolicy", "name", cr.Name, "error", err)
+		return managed.ExternalObservation{}, errors.Wrap(err, errSelectPolicy)
+	}
+	observed.AuditActions, err = auditpolicy.OptimizeAuditActions(observed.AuditActions)
+	if err != nil {
+		c.log.Info("Error optimizing audit actions", "name", cr.Name, "error", err)
+		return managed.ExternalObservation{}, err
+	}
 
 	if err != nil {
 		c.log.Info("Error observing auditpolicy", "name", cr.Name, "error", err)
@@ -200,7 +212,10 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	c.log.Info("Creating auditPolicy resource", "name", cr.Name, "policyName", cr.Spec.ForProvider.PolicyName)
 
-	parameters := buildDesiredParameters(cr)
+	parameters, err := buildDesiredParameters(cr)
+	if err != nil {
+		return managed.ExternalCreation{}, errors.Wrap(err, "error building desired parameters for creation")
+	}
 
 	c.log.Info("Creating auditPolicy with parameters",
 		"policyName", parameters.PolicyName,
@@ -212,7 +227,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	cr.SetConditions(xpv1.Creating())
 
-	err := c.client.Create(ctx, parameters)
+	err = c.client.Create(ctx, parameters)
 
 	if err != nil {
 		c.log.Info("Error creating auditpolicy", "name", cr.Name, "error", err)
@@ -230,8 +245,11 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 	c.log.Info("Updating audit policy resource", "name", cr.Name, "policyName", cr.Spec.ForProvider.PolicyName)
 
-	observed := buildObservedParameters(cr)
-	desired := buildDesiredParameters(cr)
+	observed, _ := buildObservedParameters(cr)
+	desired, err := buildDesiredParameters(cr)
+	if err != nil {
+		return managed.ExternalUpdate{}, errors.Wrap(err, "error building desired parameters")
+	}
 
 	// if audit actions, status or level differ, we need to drop and recreate the policy
 	if needsRecreation(observed, desired) {
@@ -301,11 +319,14 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	c.log.Info("Deleting auditpolicy resource", "name", cr.Name, "schemaName", cr.Spec.ForProvider.PolicyName)
 
-	parameters := buildDesiredParameters(cr)
+	parameters, err := buildDesiredParameters(cr)
+	if err != nil {
+		return managed.ExternalDelete{}, errors.Wrap(err, "error building desired parameters for deletion")
+	}
 
 	cr.SetConditions(xpv1.Deleting())
 
-	err := c.client.Delete(ctx, parameters)
+	err = c.client.Delete(ctx, parameters)
 
 	if err != nil {
 		c.log.Info("Error deleting auditpolicy", "name", cr.Name, "error", err)
@@ -316,20 +337,29 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 	return managed.ExternalDelete{}, err
 }
 
-func buildObservedParameters(cr *v1alpha1.AuditPolicy) *v1alpha1.AuditPolicyObservation {
+func buildObservedParameters(cr *v1alpha1.AuditPolicy) (*v1alpha1.AuditPolicyObservation, error) {
 	observed := cr.Status.AtProvider.DeepCopy()
-	return observed
+	auditActions, err := auditpolicy.OptimizeAuditActions(observed.AuditActions)
+	if err != nil {
+		return nil, err
+	}
+	observed.AuditActions = auditActions
+	return observed, nil
 }
 
-func buildDesiredParameters(cr *v1alpha1.AuditPolicy) *v1alpha1.AuditPolicyParameters {
+func buildDesiredParameters(cr *v1alpha1.AuditPolicy) (*v1alpha1.AuditPolicyParameters, error) {
+	auditActions, err := auditpolicy.OptimizeAuditActions(cr.Spec.ForProvider.AuditActions)
+	if err != nil {
+		return nil, err
+	}
 	return &v1alpha1.AuditPolicyParameters{
 		PolicyName:          strings.ToUpper(cr.Spec.ForProvider.PolicyName),
 		AuditStatus:         strings.ToUpper(cr.Spec.ForProvider.AuditStatus),
-		AuditActions:        utils.ArrayToUpper(cr.Spec.ForProvider.AuditActions),
+		AuditActions:        auditActions,
 		AuditLevel:          strings.ToUpper(cr.Spec.ForProvider.AuditLevel),
 		AuditTrailRetention: cr.Spec.ForProvider.AuditTrailRetention,
 		Enabled:             cr.Spec.ForProvider.Enabled,
-	}
+	}, nil
 }
 
 func needsRecreation(observed *v1alpha1.AuditPolicyObservation, desired *v1alpha1.AuditPolicyParameters) bool {

--- a/internal/controller/auditpolicy/reconciler.go
+++ b/internal/controller/auditpolicy/reconciler.go
@@ -166,21 +166,15 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	if err != nil {
 		c.log.Info("Error observing auditpolicy", "name", cr.Name, "error", err)
 		return managed.ExternalObservation{}, errors.Wrap(err, errSelectPolicy)
+	} else if observed == nil || observed.PolicyName == "" || observed.PolicyName != parameters.PolicyName {
+		c.log.Info("AuditPolicy does not exist", "name", cr.Name, "policyName", parameters.PolicyName)
+		return managed.ExternalObservation{ResourceExists: false}, nil
 	}
+
 	observed.AuditActions, err = auditpolicy.OptimizeAuditActions(observed.AuditActions)
 	if err != nil {
 		c.log.Info("Error optimizing audit actions", "name", cr.Name, "error", err)
 		return managed.ExternalObservation{}, err
-	}
-
-	if err != nil {
-		c.log.Info("Error observing auditpolicy", "name", cr.Name, "error", err)
-		return managed.ExternalObservation{}, errors.Wrap(err, errSelectPolicy)
-	}
-
-	if observed == nil || observed.PolicyName == "" || observed.PolicyName != parameters.PolicyName {
-		c.log.Info("AuditPolicy does not exist", "name", cr.Name, "policyName", parameters.PolicyName)
-		return managed.ExternalObservation{ResourceExists: false}, nil
 	}
 
 	cr.Status.AtProvider.PolicyName = observed.PolicyName
@@ -245,7 +239,10 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 	c.log.Info("Updating audit policy resource", "name", cr.Name, "policyName", cr.Spec.ForProvider.PolicyName)
 
-	observed, _ := buildObservedParameters(cr)
+	observed, err := buildObservedParameters(cr)
+	if err != nil {
+		return managed.ExternalUpdate{}, errors.Wrap(err, "error building observed parameters")
+	}
 	desired, err := buildDesiredParameters(cr)
 	if err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, "error building desired parameters")


### PR DESCRIPTION


# AuditPolicy action parsing & optimization

## Summary

Introduce a robust audit-action parsing and optimization layer, extend the AuditPolicy client and reconciler to support richer principal-aware reads and multi-query CREATEs, and add new end-to-end tests and fixtures for AuditPolicy, Role, Usergroup and related resources.

This PR normalizes, groups, and validates audit action strings so the controller and client produce predictable SQL and behavior when working with principals and complex action clauses.

## What changed

- New audit action parsing/optimization utilities:
  - `OptimizeAuditActions` and helpers to parse action strings (supports `FOR PRINCIPALS`, `EXCEPT FOR`, `USER`, `USERGROUP`).
  - Internal types: `parsedAction`, `parsedPrincipal` and stringify/grouping helpers.
- `internal/clients/hana/auditpolicy/auditpolicy_client.go`:
  - Read now scans principal columns (`PRINCIPAL_NAME`, `EXCEPT_PRINCIPAL_NAME`, `PRINCIPAL_TYPE`) and reconstructs full action strings.
  - `prepareCreateSql` now returns multiple SQL statements (one per action variant); `Create` runs each query.
  - `getSelectSql` updated to select principal-related columns.
- `internal/controller/auditpolicy/reconciler.go`:
  - Parameter builders now return errors.
  - Reconciler calls `OptimizeAuditActions` for observed/desired inputs, and bubbles errors with logging.
- Tests & fixtures:

## Behavioral notes

- `OptimizeAuditActions` normalizes and groups actions, but currently returns an error if grouping yields more than one grouped action (this is an intentional guard).
- CREATE logic will issue multiple `CREATE AUDIT POLICY` variants when multiple action strings are present.
- Read paths now include principal context, so observed `AuditActions` contain `FOR PRINCIPALS` / `EXCEPT FOR PRINCIPALS` fragments when applicable.

## How to validate

Manual smoke test:
- Apply the CR: `kubectl apply -f {path/to/auditpolicy.yaml}`
- Observe the provider logs and the created DB audit policy; check `AuditActions` in the CR status reflect normalized `FOR/EXCEPT` principal fragments.

## Migration & rollout notes

- Existing policies with complex multi-action combinations may hit the current grouping guard and return an error — review policies that expect multiple independent grouped actions.
- If you depend on the old, un-normalized string formatting, validate consumer integrations that read `AuditActions` from the CR status.

## Risks & follow-ups

- Relax grouping limit: support multiple grouped actions instead of erroring.
- Add unit tests for parsing edge cases (user vs usergroup, comma spacing, capitalization, unexpected tokens).
- Add SQL escaping tests for `PolicyName` and principal values.