### PR TITLE
feat: add PrivilegeGrantablePolicy to skip failing grant / admin checks

### DIFF
--- a/apis/admin/v1alpha1/user_types.go
+++ b/apis/admin/v1alpha1/user_types.go
@@ -109,6 +109,15 @@ type UserSpec struct {
 	// 'strict' means that all privileges are managed by crossplane, and other privileges not defined in the spec will be removed.
 	// 'lax' means that crossplane will only manage the privileges defined in the spec, and other privileges will not be removed.
 	PrivilegeManagementPolicy string `json:"privilegeManagementPolicy,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=strict;lax
+	// +kubebuilder:default:=strict
+	// PrivilegeGrantablePolicy defines how admin/grant options are handled during privilege comparison.
+	// 'strict' means the presence or absence of WITH ADMIN/GRANT OPTION must match exactly.
+	// 'lax' means the WITH ADMIN/GRANT OPTION suffix is ignored when comparing desired vs observed privileges.
+	// Use 'lax' when the DB instance automatically sets IS_GRANTABLE=true.
+	PrivilegeGrantablePolicy string `json:"privilegeGrantablePolicy,omitempty"`
 }
 
 // A UserStatus represents the observed state of a User.

--- a/internal/clients/hana/privilege/privilege.go
+++ b/internal/clients/hana/privilege/privilege.go
@@ -712,3 +712,61 @@ func handlePrivilegeRows(privRows *sql.Rows) (Privilege, error) {
 		return createRegularObjectPrivilege(privilege, schemaName, objectName, isGrantable), nil
 	}
 }
+
+// privilegeBaseKey uniquely identifies a privilege ignoring its grantable state.
+type privilegeBaseKey struct {
+	pType         PrivilegeType
+	name          string
+	identifier    string
+	subIdentifier string
+}
+
+func privilegeToBaseKey(p Privilege) privilegeBaseKey {
+	return privilegeBaseKey{p.Type, p.Name, p.Identifier, p.SubIdentifier}
+}
+
+// PrivilegesEqualIgnoringGrantable returns true when desired and observed privilege
+// string slices refer to the same privileges, ignoring admin/grant option entirely.
+// Used when privilegeGrantablePolicy is "lax".
+func PrivilegesEqualIgnoringGrantable(desired, observed []string, defaultSchema DefaultSchema) (bool, error) {
+	toGrant, toRevoke, err := PrivilegesDiffIgnoringGrantable(desired, observed, defaultSchema)
+	if err != nil {
+		return false, err
+	}
+	return len(toGrant) == 0 && len(toRevoke) == 0, nil
+}
+
+// PrivilegesDiffIgnoringGrantable returns toGrant and toRevoke slices, ignoring
+// admin/grant option when comparing desired vs observed. Used when
+// privilegeGrantablePolicy is "lax".
+func PrivilegesDiffIgnoringGrantable(desired, observed []string, defaultSchema DefaultSchema) (toGrant, toRevoke []string, err error) {
+	desiredPrivs, err := parsePrivilegeStrings(desired, defaultSchema)
+	if err != nil {
+		return nil, nil, err
+	}
+	observedPrivs, err := parsePrivilegeStrings(observed, defaultSchema)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	observedKeys := make(map[privilegeBaseKey]bool, len(observedPrivs))
+	for _, p := range observedPrivs {
+		observedKeys[privilegeToBaseKey(p)] = true
+	}
+
+	desiredKeys := make(map[privilegeBaseKey]bool, len(desiredPrivs))
+	for _, d := range desiredPrivs {
+		desiredKeys[privilegeToBaseKey(d)] = true
+		if !observedKeys[privilegeToBaseKey(d)] {
+			toGrant = append(toGrant, d.String())
+		}
+	}
+
+	for _, o := range observedPrivs {
+		if !desiredKeys[privilegeToBaseKey(o)] {
+			toRevoke = append(toRevoke, o.String())
+		}
+	}
+
+	return toGrant, toRevoke, nil
+}

--- a/internal/clients/hana/privilege/privilege_test.go
+++ b/internal/clients/hana/privilege/privilege_test.go
@@ -1429,3 +1429,66 @@ func TestFormatSpecialObjectPrivilege(t *testing.T) {
 		})
 	}
 }
+
+func TestPrivilegesEqualIgnoringGrantable(t *testing.T) {
+	cases := []struct {
+		name     string
+		desired  []string
+		observed []string
+		want     bool
+	}{
+		{
+			name:     "ExactMatch",
+			desired:  []string{"CREATE SCHEMA WITH ADMIN OPTION"},
+			observed: []string{"CREATE SCHEMA WITH ADMIN OPTION"},
+			want:     true,
+		},
+		{
+			name:     "BothWithout",
+			desired:  []string{"CREATE SCHEMA"},
+			observed: []string{"CREATE SCHEMA"},
+			want:     true,
+		},
+		{
+			name:     "DesiredWithoutObservedWith",
+			desired:  []string{"CREATE SCHEMA"},
+			observed: []string{"CREATE SCHEMA WITH ADMIN OPTION"},
+			want:     true,
+		},
+		{
+			name:     "DesiredWithObservedWithout",
+			desired:  []string{"CREATE SCHEMA WITH ADMIN OPTION"},
+			observed: []string{"CREATE SCHEMA"},
+			want:     true,
+		},
+		{
+			name:     "MissingObserved",
+			desired:  []string{"CREATE SCHEMA"},
+			observed: []string{},
+			want:     false,
+		},
+		{
+			name:     "ExtraObserved",
+			desired:  []string{},
+			observed: []string{"CREATE SCHEMA"},
+			want:     false,
+		},
+		{
+			name:     "MultipleIgnoresGrantable",
+			desired:  []string{"CREATE SCHEMA", "SELECT ON SCHEMA myschema"},
+			observed: []string{"CREATE SCHEMA WITH ADMIN OPTION", "SELECT ON SCHEMA myschema WITH GRANT OPTION"},
+			want:     true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := PrivilegesEqualIgnoringGrantable(tc.desired, tc.observed, "defaultschema")
+			if err != nil {
+				t.Fatalf("PrivilegesEqualIgnoringGrantable() unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("PrivilegesEqualIgnoringGrantable(%v, %v) = %v, want %v", tc.desired, tc.observed, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/user/reconciler.go
+++ b/internal/controller/user/reconciler.go
@@ -237,7 +237,12 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		cr.SetConditions(xpv1.Available())
 	}
 
-	isUpToDate := upToDate(observed, parameters)
+	isUpToDate, err := upToDate(observed, parameters, c.client.GetDefaultSchema(), cr.Spec.PrivilegeGrantablePolicy)
+
+	if err != nil {
+		c.log.Info("Error comparing privileges", "name", cr.Name, "error", err)
+		return managed.ExternalObservation{}, fmt.Errorf("cannot compare privileges: %w", err)
+	}
 
 	c.log.Info("Observed user resource",
 		"name", cr.Name,
@@ -250,16 +255,31 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}, nil
 }
 
-func upToDate(observed *v1alpha1.UserObservation, desired *v1alpha1.UserParameters) bool {
-	return isPasswordUpToDate(observed, desired) &&
+func privilegesUpToDate(desired *v1alpha1.UserParameters, observed *v1alpha1.UserObservation, grantablePolicy string, defaultSchema string) (bool, error) {
+	var privilegesEqual bool
+	var err error
+	if grantablePolicy == "lax" {
+		privilegesEqual, err = privilege.PrivilegesEqualIgnoringGrantable(desired.Privileges, observed.Privileges, defaultSchema)
+	} else {
+		privilegesEqual = utils.ArraysEqual(desired.Privileges, observed.Privileges)
+	}
+	return privilegesEqual, err
+}
+
+func upToDate(observed *v1alpha1.UserObservation, desired *v1alpha1.UserParameters, defaultSchema, grantablePolicy string) (bool, error) {
+	privilegesEqual, err := privilegesUpToDate(desired, observed, grantablePolicy, defaultSchema)
+	if err != nil {
+		return false, err
+	}
+	return privilegesEqual &&
+		isPasswordUpToDate(observed, desired) &&
 		isX509MappingsUpToDate(observed, desired) &&
 		observed.Usergroup != nil &&
 		*observed.Usergroup == desired.Usergroup &&
 		observed.IsPasswordLifetimeCheckEnabled != nil &&
 		*observed.IsPasswordLifetimeCheckEnabled == desired.IsPasswordLifetimeCheckEnabled &&
 		maps.Equal(observed.Parameters, desired.Parameters) &&
-		utils.ArraysEqual(observed.Privileges, desired.Privileges) &&
-		utils.ArraysEqual(observed.Roles, desired.Roles)
+		utils.ArraysEqual(observed.Roles, desired.Roles), nil
 }
 
 func isPasswordUpToDate(observed *v1alpha1.UserObservation, desired *v1alpha1.UserParameters) bool {
@@ -373,8 +393,18 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 }
 
 func (c *external) updatePrivileges(ctx context.Context, cr *v1alpha1.User, desired *v1alpha1.UserParameters, observed *v1alpha1.UserObservation) error {
-	// Update privileges if needed
-	if isEqual, toGrant, toRevoke := utils.ArraysBothDiff(desired.Privileges, observed.Privileges); !isEqual {
+	var toGrant, toRevoke []string
+	if cr.Spec.PrivilegeGrantablePolicy == "lax" {
+		var err error
+		toGrant, toRevoke, err = privilege.PrivilegesDiffIgnoringGrantable(desired.Privileges, observed.Privileges, c.client.GetDefaultSchema())
+		if err != nil {
+			c.log.Info("Error computing privilege diff", "name", cr.Name, "error", err)
+			return fmt.Errorf(errUpdateUser, err)
+		}
+	} else {
+		_, toGrant, toRevoke = utils.ArraysBothDiff(desired.Privileges, observed.Privileges)
+	}
+	if len(toGrant) > 0 || len(toRevoke) > 0 {
 		c.log.Info("Updating user privileges",
 			"name", cr.Name,
 			"username", desired.Username,

--- a/internal/controller/user/reconciler_test.go
+++ b/internal/controller/user/reconciler_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 const demoUser = "DEMO_USER"
+const defaultConstant = "DEFAULT"
 
 // MockLogger is a mock implementation of logging.Logger
 type MockLogger struct {
@@ -305,7 +306,7 @@ func TestObserve(t *testing.T) {
 							Username:                       new(demoUser),
 							Privileges:                     []string{privilege.GetDefaultPrivilege("DEMO_USER")},
 							Roles:                          []string{"PUBLIC"},
-							Usergroup:                      new("DEFAULT"),
+							Usergroup:                      new(defaultConstant),
 							PasswordUpToDate:               nil, // No password authentication
 							IsPasswordLifetimeCheckEnabled: new(true),
 							Parameters:                     make(map[string]string),
@@ -320,7 +321,7 @@ func TestObserve(t *testing.T) {
 					Spec: v1alpha1.UserSpec{
 						ForProvider: v1alpha1.UserParameters{
 							Username:                       demoUser,
-							Usergroup:                      "DEFAULT",
+							Usergroup:                      defaultConstant,
 							IsPasswordLifetimeCheckEnabled: true,
 						},
 						PrivilegeManagementPolicy: "strict",
@@ -344,7 +345,7 @@ func TestObserve(t *testing.T) {
 							Username:                       new(demoUser),
 							Privileges:                     []string{"SELECT", "INSERT", privilege.GetDefaultPrivilege("DEMO_USER")},
 							Roles:                          []string{"PUBLIC"},
-							Usergroup:                      new("DEFAULT"),
+							Usergroup:                      new(defaultConstant),
 							PasswordUpToDate:               nil, // No password authentication
 							IsPasswordLifetimeCheckEnabled: new(true),
 							Parameters:                     make(map[string]string),
@@ -360,7 +361,7 @@ func TestObserve(t *testing.T) {
 						ForProvider: v1alpha1.UserParameters{
 							Username:                       demoUser,
 							Privileges:                     []string{"SELECT", "INSERT"},
-							Usergroup:                      "DEFAULT",
+							Usergroup:                      defaultConstant,
 							IsPasswordLifetimeCheckEnabled: true,
 						},
 						PrivilegeManagementPolicy: "strict",
@@ -384,7 +385,7 @@ func TestObserve(t *testing.T) {
 							Username:                       new(demoUser),
 							Privileges:                     []string{"SELECT", "INSERT", "DELETE", "UPDATE"},
 							Roles:                          []string{"PUBLIC"},
-							Usergroup:                      new("DEFAULT"),
+							Usergroup:                      new(defaultConstant),
 							PasswordUpToDate:               nil, // No password authentication
 							IsPasswordLifetimeCheckEnabled: new(true),
 						}, nil
@@ -399,7 +400,7 @@ func TestObserve(t *testing.T) {
 							Username:   demoUser,
 							Privileges: []string{"SELECT", "INSERT"},
 
-							Usergroup:                      "DEFAULT",
+							Usergroup:                      defaultConstant,
 							IsPasswordLifetimeCheckEnabled: true,
 						},
 						PrivilegeManagementPolicy: "lax",
@@ -485,7 +486,7 @@ func TestObserve(t *testing.T) {
 							Username:                       new(demoUser),
 							Privileges:                     []string{privilege.GetDefaultPrivilege("DEFAULT_SCHEMA"), "SELECT", "INSERT", "UPDATE"},
 							Roles:                          []string{"PUBLIC"},
-							Usergroup:                      new("DEFAULT"),
+							Usergroup:                      new(defaultConstant),
 							PasswordUpToDate:               nil, // No password authentication
 							IsPasswordLifetimeCheckEnabled: new(true),
 						}, nil
@@ -499,7 +500,7 @@ func TestObserve(t *testing.T) {
 						ForProvider: v1alpha1.UserParameters{
 							Username:                       demoUser,
 							Privileges:                     []string{"SELECT", "INSERT", "UPDATE"},
-							Usergroup:                      "DEFAULT",
+							Usergroup:                      defaultConstant,
 							IsPasswordLifetimeCheckEnabled: true,
 						},
 						PrivilegeManagementPolicy: "lax",
@@ -529,7 +530,7 @@ func TestObserve(t *testing.T) {
 							Username:                       new(demoUser),
 							Privileges:                     []string{privilege.GetDefaultPrivilege("DEMO_USER"), "SELECT", "INSERT", "UPDATE"},
 							Roles:                          []string{"PUBLIC"},
-							Usergroup:                      new("DEFAULT"),
+							Usergroup:                      new(defaultConstant),
 							PasswordUpToDate:               nil, // No password authentication
 							IsPasswordLifetimeCheckEnabled: new(true),
 						}, nil
@@ -543,7 +544,7 @@ func TestObserve(t *testing.T) {
 						ForProvider: v1alpha1.UserParameters{
 							Username:                       demoUser,
 							Privileges:                     []string{"SELECT", "INSERT", "SELECT", "UPDATE"},
-							Usergroup:                      "DEFAULT",
+							Usergroup:                      defaultConstant,
 							IsPasswordLifetimeCheckEnabled: true,
 						},
 						PrivilegeManagementPolicy: "strict",
@@ -567,7 +568,7 @@ func TestObserve(t *testing.T) {
 							Username:                       new(demoUser),
 							Privileges:                     []string{"CREATE ANY"},
 							Roles:                          []string{"PUBLIC"},
-							Usergroup:                      new("DEFAULT"),
+							Usergroup:                      new(defaultConstant),
 							PasswordUpToDate:               new(true),
 							IsPasswordLifetimeCheckEnabled: new(false), // Different from desired
 						}, nil
@@ -580,7 +581,7 @@ func TestObserve(t *testing.T) {
 					Spec: v1alpha1.UserSpec{
 						ForProvider: v1alpha1.UserParameters{
 							Username:                       demoUser,
-							Usergroup:                      "DEFAULT",
+							Usergroup:                      defaultConstant,
 							IsPasswordLifetimeCheckEnabled: true, // Desired state
 						},
 						PrivilegeManagementPolicy: "strict",
@@ -969,3 +970,90 @@ func TestGenerateReconcileRequestsFromSecret(t *testing.T) {
 		})
 	}
 }
+
+func TestUpToDate_PrivilegeGrantablePolicy(t *testing.T) {
+	trueVal := true
+	var defaultGroup = defaultConstant
+
+	baseObserved := func(privs []string) *v1alpha1.UserObservation {
+		return &v1alpha1.UserObservation{
+			Username:                       strPtr(demoUser),
+			Usergroup:                      &defaultGroup,
+			IsPasswordLifetimeCheckEnabled: &trueVal,
+			Privileges:                     privs,
+		}
+	}
+	baseDesired := func(privs []string) *v1alpha1.UserParameters {
+		return &v1alpha1.UserParameters{
+			Username:                       demoUser,
+			Usergroup:                      defaultGroup,
+			IsPasswordLifetimeCheckEnabled: true,
+			Privileges:                     privs,
+		}
+	}
+
+	cases := []struct {
+		name          string
+		policy        string
+		desiredPrivs  []string
+		observedPrivs []string
+		wantUpToDate  bool
+	}{
+		{
+			name:          "Strict_ExactMatch",
+			policy:        "strict",
+			desiredPrivs:  []string{"CREATE SCHEMA"},
+			observedPrivs: []string{"CREATE SCHEMA"},
+			wantUpToDate:  true,
+		},
+		{
+			name:          "Strict_GrantableMismatch_NotUpToDate",
+			policy:        "strict",
+			desiredPrivs:  []string{"CREATE SCHEMA"},
+			observedPrivs: []string{"CREATE SCHEMA WITH ADMIN OPTION"},
+			wantUpToDate:  false,
+		},
+		{
+			name:          "Strict_ExplicitWithAdmin_ExactMatch",
+			policy:        "strict",
+			desiredPrivs:  []string{"CREATE SCHEMA WITH ADMIN OPTION"},
+			observedPrivs: []string{"CREATE SCHEMA WITH ADMIN OPTION"},
+			wantUpToDate:  true,
+		},
+		{
+			name:          "Lax_DesiredWithoutObservedWith_UpToDate",
+			policy:        "lax",
+			desiredPrivs:  []string{"CREATE SCHEMA"},
+			observedPrivs: []string{"CREATE SCHEMA WITH ADMIN OPTION"},
+			wantUpToDate:  true,
+		},
+		{
+			name:          "Lax_DesiredWithObservedWithout_UpToDate",
+			policy:        "lax",
+			desiredPrivs:  []string{"CREATE SCHEMA WITH ADMIN OPTION"},
+			observedPrivs: []string{"CREATE SCHEMA"},
+			wantUpToDate:  true,
+		},
+		{
+			name:          "Lax_MissingPrivilege_NotUpToDate",
+			policy:        "lax",
+			desiredPrivs:  []string{"CREATE SCHEMA", "SELECT ON SCHEMA myschema"},
+			observedPrivs: []string{"CREATE SCHEMA WITH ADMIN OPTION"},
+			wantUpToDate:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := upToDate(baseObserved(tc.observedPrivs), baseDesired(tc.desiredPrivs), "defaultschema", tc.policy)
+			if err != nil {
+				t.Fatalf("upToDate() unexpected error: %v", err)
+			}
+			if got != tc.wantUpToDate {
+				t.Errorf("upToDate() = %v, want %v", got, tc.wantUpToDate)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/package/crds/admin.hana.sap.crossplane.io_users.yaml
+++ b/package/crds/admin.hana.sap.crossplane.io_users.yaml
@@ -214,6 +214,17 @@ spec:
                   - '*'
                   type: string
                 type: array
+              privilegeGrantablePolicy:
+                default: strict
+                description: |-
+                  PrivilegeGrantablePolicy defines how admin/grant options are handled during privilege comparison.
+                  'strict' means the presence or absence of WITH ADMIN/GRANT OPTION must match exactly.
+                  'lax' means the WITH ADMIN/GRANT OPTION suffix is ignored when comparing desired vs observed privileges.
+                  Use 'lax' when the DB instance automatically sets IS_GRANTABLE=true.
+                enum:
+                - strict
+                - lax
+                type: string
               privilegeManagementPolicy:
                 default: strict
                 description: |-


### PR DESCRIPTION
Linked to an internal JIRA ticket. In normal (Crossplane) setup, we expect to trigger granting `CREATE SCHEMA` privilege without admin option on the HANA DB side as a result of specifying `CREATE SCHEMA` in the user `spec.forProvider.privileges`. But as @CsDenes observed in a different Terraform-based setup, the same privilege assignment triggers `CREATE SCHEMA WITH ADMIN OPTION` on the HANA DB side (instead of `CREATE SCHEMA`). This led to the unwanted behavior that we performed privilege updates repetitively due to observed changes in "with / without admin option".

To work around that, we suggest modifying the user API so that different behaviors can be configured on user level. If `privilegeGrantablePolicy` is set to `strict` (per default), we exactly match whether `CREATE SCHEMA WITH ADMIN OPTION` or `CREATE SCHEMA` was requested or not. Otherwise, if `privilegeGrantablePolicy` is set to `lax` , we ignore grantable option while matching privileges. 