### PR TITLE
feat: Add support for subaccount-api-access platform in instancemapping

### DIFF
--- a/apis/inventory/v1alpha1/instancemapping_types.go
+++ b/apis/inventory/v1alpha1/instancemapping_types.go
@@ -36,9 +36,9 @@ type InstanceMappingParameters struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="serviceInstanceID is immutable"
 	ServiceInstanceID string `json:"serviceInstanceID"`
 
-	// Platform is the deployment platform ("kubernetes" or "cloudfoundry")
+	// Platform is the deployment platform ("kubernetes" or "cloudfoundry" or "subaccount-api-access")
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=kubernetes;cloudfoundry
+	// +kubebuilder:validation:Enum=kubernetes;cloudfoundry;subaccount-api-access
 	Platform string `json:"platform"`
 
 	// PrimaryID is the cluster identifier (for kubernetes) or org GUID (for cloudfoundry)

--- a/package/crds/inventory.hana.orchestrate.cloud.sap_instancemappings.yaml
+++ b/package/crds/inventory.hana.orchestrate.cloud.sap_instancemappings.yaml
@@ -103,10 +103,11 @@ spec:
                     type: boolean
                   platform:
                     description: Platform is the deployment platform ("kubernetes"
-                      or "cloudfoundry")
+                      or "cloudfoundry" or "subaccount-api-access")
                     enum:
                     - kubernetes
                     - cloudfoundry
+                    - subaccount-api-access
                     type: string
                   primaryID:
                     description: PrimaryID is the cluster identifier (for kubernetes)


### PR DESCRIPTION
Extend the existing `InstanceMapping` CRD to support BTP subaccount-level sharing by adding `subaccount-api-access` as a valid value for the `platform` field. This enables declarative sharing of a HANA Cloud database instance with another BTP subaccount via the SAP HANA Cloud Admin REST API. 

Such instance mapping is required to create tenant DB to shared HANA instances or HANA instances in other subaccounts.

reference : https://help.sap.com/docs/hana-cloud/sap-hana-cloud-multitenancy/share-database-tenant-with-other-subaccounts-using-tenant-management-service-rest-api?locale=en-US&q=mapping

