### PR TITLE
fix: pin crossplane tools v1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/crossplane-contrib/xp-testing v1.9.2
 	github.com/crossplane/crossplane-runtime v1.20.0
-	github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339
+	github.com/crossplane/crossplane-tools v0.0.0-20250422201939-01c86c11b835
 	github.com/google/go-cmp v0.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/crossplane-contrib/xp-testing v1.9.2 h1:atclGXOX59H88h6HIFlyiQglJmf3T
 github.com/crossplane-contrib/xp-testing v1.9.2/go.mod h1:akx1+mAXBKJ7CfO/Tmf8LaGZTPeOqBg/qjwt9yMdOww=
 github.com/crossplane/crossplane-runtime v1.20.0 h1:I54uipRIecqZyms+vz1J/l62yjVQ7HV5w+Nh3RMrUtc=
 github.com/crossplane/crossplane-runtime v1.20.0/go.mod h1:lfV1VJenDc9PNVLxDC80YjPoTm+JdSZ13xlS2h37Dvg=
-github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339 h1:MPbMxSlY+82UsjrLUAGyXlh/iX1tL5WNj8W9SOaq/nk=
-github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339/go.mod h1:8etxwmP4cZwJDwen4+PQlnc1tggltAhEfyyigmdHulQ=
+github.com/crossplane/crossplane-tools v0.0.0-20250422201939-01c86c11b835 h1:x6XWYLT22+A87SqzoBFtF5hEK7ogzYLTnwyOmf/lmnE=
+github.com/crossplane/crossplane-tools v0.0.0-20250422201939-01c86c11b835/go.mod h1:8etxwmP4cZwJDwen4+PQlnc1tggltAhEfyyigmdHulQ=
 github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=
 github.com/dave/jennifer v1.7.1/go.mod h1:nXbxhEmQfOZhWml3D1cDK5M1FLnMSozpbFN/m3RmGZc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,12 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
-  "labels": ["release-notes/dependencies"]
+  "labels": ["release-notes/dependencies"],
+  "packageRules": [
+    {
+      "description": "Pin crossplane-tools: digests after 2025-10-17 hardcode crossplane-runtime/v2 import paths in angryjet, which silently produces no output for this v1-based project. Do not upgrade without also migrating to crossplane-runtime v2. See commit 11444c0 and the re-upgrade regression in cfdbd13.",
+      "matchPackageNames": ["github.com/crossplane/crossplane-tools"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
I broke this when merging a renovate PR - see description below in the rules for details.