### PR TITLE
fix: relax CRD validation for User.username and AuditPolicy.auditActions

### DIFF
--- a/apis/admin/v1alpha1/auditpolicy_types.go
+++ b/apis/admin/v1alpha1/auditpolicy_types.go
@@ -17,7 +17,7 @@ import (
 type AuditPolicyParameters struct {
 	PolicyName string `json:"policyName"`
 
-	// +kubebuilder:validation:items:Pattern:=`^[^",\$\.'\+\-<>|\[\]\{\}\(\)!%*,/:;=\?@\\^~\x60]+$`
+	// +kubebuilder:validation:items:Pattern:=`^[^",\$'\+<>|\[\]\{\}\(\)!%,/:;=\?@\\^~\x60]+$`
 	// +listType=set
 	AuditActions []string `json:"auditActions"`
 

--- a/apis/admin/v1alpha1/user_types.go
+++ b/apis/admin/v1alpha1/user_types.go
@@ -29,7 +29,7 @@ type Password struct {
 type UserParameters struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
-	// +kubebuilder:validation:Pattern:=`^[^",\$\.'\+\-<>|\[\]\{\}\(\)!%*,/:;=\?@\\^~\x60]+$`
+	// +kubebuilder:validation:Pattern:=`^[^",\$\.'\+<>|\[\]\{\}\(\)!%*,/:;=\?@\\^~\x60]+$`
 	Username string `json:"username"`
 
 	// +kubebuilder:validation:Optional

--- a/package/crds/admin.hana.sap.crossplane.io_auditpolicies.yaml
+++ b/package/crds/admin.hana.sap.crossplane.io_auditpolicies.yaml
@@ -76,7 +76,7 @@ spec:
                 properties:
                   auditActions:
                     items:
-                      pattern: ^[^",\$\.'\+\-<>|\[\]\{\}\(\)!%*,/:;=\?@\\^~\x60]+$
+                      pattern: ^[^",\$'\+<>|\[\]\{\}\(\)!%,/:;=\?@\\^~\x60]+$
                       type: string
                     type: array
                     x-kubernetes-list-type: set

--- a/package/crds/admin.hana.sap.crossplane.io_users.yaml
+++ b/package/crds/admin.hana.sap.crossplane.io_users.yaml
@@ -181,7 +181,7 @@ spec:
                     pattern: ^[^",\$\.'\+\-<>|\[\]\{\}\(\)!%*,/:;=\?@\\^~\x60]+$
                     type: string
                   username:
-                    pattern: ^[^",\$\.'\+\-<>|\[\]\{\}\(\)!%*,/:;=\?@\\^~\x60]+$
+                    pattern: ^[^",\$\.'\+<>|\[\]\{\}\(\)!%*,/:;=\?@\\^~\x60]+$
                     type: string
                     x-kubernetes-validations:
                     - message: Value is immutable


### PR DESCRIPTION
Closes #131
Closes #132

## Summary

The `User` and `AuditPolicy` CRDs share an identifier regex that is stricter than what SAP HANA itself accepts, so valid HANA users and audit policies cannot be modelled as Crossplane resources:

- `User.spec.forProvider.username` rejects hyphens, blocking names that HANA itself accepts via `CREATE USER ...` (#131).
- `AuditPolicy.spec.forProvider.auditActions` rejects `.` and `*`, blocking standard expressions such as `EXECUTE ON _SYS_DI.*` (#132).

In both cases the resource is rejected by API-server validation before reconciliation begins, so there is no workaround short of bypassing the CRD.

## Note on the HANA docs

The HANA docs currently list `-` in the "characters not permitted in user names" table ([HANA Cloud](https://help.sap.com/docs/hana-cloud-database/sap-hana-cloud-sap-hana-database-security-guide/characters-not-permitted-in-user-names?locale=en-US)), but HANA itself accepts hyphens. SAP HANA Support has confirmed this is a documentation error and raised it with the responsible team. We're aligning the CRD with actual HANA behaviour rather than the (incorrect) docs.