### PR TITLE
docs: add prominent CRD browser link to HANA overview page

### DIFF
--- a/docs/end-user-guides/hana.mdx
+++ b/docs/end-user-guides/hana.mdx
@@ -6,6 +6,8 @@ sidebar_position: 0
 
 The guides in our end user guides section will walk you through a complete end-to-end use case for managing SAP HANA Cloud resources with Crossplane as code.
 
+<a href="https://doc.crds.dev/github.com/SAP/crossplane-provider-hana" target="_blank" className="button button--primary button--lg" style={{marginBottom: '1.5rem', display: 'inline-block'}}>Browse HANA CRDs ↗</a>
+
 To realize the use case, you'll:
 
 - [Order a HANA Cloud instance and set up the HANA provider](/docs/crossplane-provider-hana/docs/end-user-guides/setup).


### PR DESCRIPTION
## Summary

Adds a primary button at the top of the HANA end-user guide overview page linking directly to the [CRD browser on doc.crds.dev](https://doc.crds.dev/github.com/SAP/crossplane-provider-hana), making it easy for users to quickly look up resource definitions.

Part of a broader effort to surface CRD browser links across the Crossplane provider docs — see also [crossplane-provider-docs#131](https://github.com/SAP/crossplane-provider-docs/pull/131).

## Test plan

- [ ] Open the HANA end-user guide overview page
- [ ] Verify "Browse HANA CRDs ↗" button appears below the page title
- [ ] Verify clicking it opens `https://doc.crds.dev/github.com/SAP/crossplane-provider-hana` in a new tab